### PR TITLE
Add `depth 1` option to git clone in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf -y update
 RUN dnf clean all
 
 
-RUN git clone https://github.com/h-kojima/slide2mp4
+RUN git clone --depth 1 https://github.com/h-kojima/slide2mp4
 RUN cp slide2mp4/slide2mp4.sh /usr/local/bin/slide2mp4
 RUN cp slide2mp4/tools/chapters-timestamp.sh /usr/local/bin/chapters-timestamp
 RUN cp slide2mp4/tools/lexicon-generate.sh /usr/local/bin/lexicon-generate


### PR DESCRIPTION
This patch create a shallow clone with `--depth 1`.
We don't have any git history during docker build and it pulls codes much fater.